### PR TITLE
Fix Issue #38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/react-dom": "^18.2.18",
         "axios": "^1.6.7",
         "framer-motion": "^11.0.5",
-        "react": "^18.2.0",
+        "react": "^18.3.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.1",
         "react-scripts": "5.0.1",
@@ -16871,9 +16871,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "^18.2.18",
     "axios": "^1.6.7",
     "framer-motion": "^11.0.5",
-    "react": "^18.2.0",
+    "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.1",
     "react-scripts": "5.0.1",

--- a/src/api/apiClient.tsx
+++ b/src/api/apiClient.tsx
@@ -16,7 +16,7 @@ const apiClient = axios.create({
 const request = async (
   method: Method,
   url: string,
-  params?: unknown,
+  params?: unknown
 ): Promise<AxiosResponse> => {
   return await apiClient.request({ method, url });
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,14 @@
 import { Routes, Route } from "react-router-dom";
 import HomePage from "../pages/HomePage";
+import Events from "../components/Events";
+import { events } from "../data/seed";
 
 function App(): JSX.Element {
   return (
     <div>
       <Routes>
         <Route path="/" element={<HomePage />} />
+        <Route path="/events" element={<Events events={events} />} />
       </Routes>
     </div>
   );

--- a/src/components/Events.tsx
+++ b/src/components/Events.tsx
@@ -1,0 +1,50 @@
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  TableContainer,
+  Td,
+  HStack,
+} from "@chakra-ui/react";
+import { Event } from "../types/events";
+import Sidebar from "./Sidebar";
+
+function Events({ events }: { events: Event[] }): JSX.Element {
+  return (
+    <HStack height="100vh" spacing="2">
+      <Sidebar />
+      <TableContainer>
+        <Table>
+          <Thead>
+            <Tr>
+              <Th>Event Name</Th>
+              <Th>Organizer</Th>
+              <Th>Date</Th>
+              <Th>Location</Th>
+              <Th>Budget</Th>
+              <Th>Type of Event</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {events.map(
+              ({ name, organizer, date, location, budget, eventType }) => (
+                <Tr key={name}>
+                  <Td>{name}</Td>
+                  <Td>{organizer.name}</Td>
+                  <Td>{date}</Td>
+                  <Td>{location}</Td>
+                  <Td>{budget}</Td>
+                  <Td>{eventType}</Td>
+                </Tr>
+              )
+            )}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </HStack>
+  );
+}
+
+export default Events;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import HomeIcon from "./icons/HomeIcon";
 import DashboardIcon from "./icons/Dashboard";
 import BlogIcon from "./icons/BlogIcon";
 import ExpandIcon from "./icons/ExpandIcon";
+import { CalendarIcon } from "./icons/CalendarIcon";
 
 function Sidebar(): JSX.Element {
   const [hidden, setHidden] = useState(false);
@@ -96,6 +97,24 @@ function Sidebar(): JSX.Element {
                   display="flex"
                 >
                   <Text alignSelf="flex-end">Blog</Text>
+                </Button>
+              </ChakraLink>
+              <ChakraLink
+                as={ReactRouterLink}
+                to="/events"
+                _hover={{ textDecoration: "none" }}
+              >
+                <Button
+                  leftIcon={<CalendarIcon />}
+                  colorScheme="whiteAlpha"
+                  width="100%"
+                  padding="8px"
+                  justifyContent="start"
+                  backgroundColor="transparent"
+                  variant="solid"
+                  display="flex"
+                >
+                  <Text alignSelf="flex-end">Events</Text>
                 </Button>
               </ChakraLink>
             </VStack>

--- a/src/components/icons/CalendarIcon.tsx
+++ b/src/components/icons/CalendarIcon.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+// By: ion
+// See: https://v0.app/icon/ion/calendar-outline
+// Example: <IconIonCalendarOutline width="24px" height="24px" style={{color: "#000000"}} />
+
+export const CalendarIcon = ({
+  height = "1em",
+  strokeWidth = "32",
+  focusable = "false",
+  ...props
+}: Omit<React.SVGProps<SVGSVGElement>, "children">) => (
+  <svg
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    height={height}
+    focusable={focusable}
+    {...props}
+  >
+    <rect
+      width="416"
+      height="384"
+      x="48"
+      y="80"
+      fill="none"
+      stroke="currentColor"
+      strokeLinejoin="round"
+      strokeWidth={strokeWidth}
+      rx="48"
+    />
+    <circle cx="296" cy="232" r="24" fill="currentColor" />
+    <circle cx="376" cy="232" r="24" fill="currentColor" />
+    <circle cx="296" cy="312" r="24" fill="currentColor" />
+    <circle cx="376" cy="312" r="24" fill="currentColor" />
+    <circle cx="136" cy="312" r="24" fill="currentColor" />
+    <circle cx="216" cy="312" r="24" fill="currentColor" />
+    <circle cx="136" cy="392" r="24" fill="currentColor" />
+    <circle cx="216" cy="392" r="24" fill="currentColor" />
+    <circle cx="296" cy="392" r="24" fill="currentColor" />
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={strokeWidth}
+      d="M128 48v32m256-32v32"
+    />
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinejoin="round"
+      strokeWidth={strokeWidth}
+      d="M464 160H48"
+    />
+  </svg>
+);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ if (rootElement !== null) {
           <App />
         </ChakraProvider>
       </BrowserRouter>
-    </React.StrictMode>,
+    </React.StrictMode>
   );
 } else {
   console.error("Failed to find the root element");

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -11,8 +11,6 @@ import Sidebar from "../components/Sidebar";
 import React, { useEffect, useState } from "react";
 import { Member } from "../types/member";
 import { getAllMembers } from "../api/lib/member";
-import Events from "../components/Events";
-import { events } from "../data/seed";
 
 function HomePage(): JSX.Element {
   const [members, setMembers] = React.useState<Member[]>([]);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,9 +1,18 @@
-import { Center, Container, HStack, Spinner, Text } from "@chakra-ui/react";
+import {
+  Center,
+  Container,
+  HStack,
+  Spinner,
+  Tab,
+  Text,
+} from "@chakra-ui/react";
 import TableDashboard from "../components/TableDashboard";
 import Sidebar from "../components/Sidebar";
 import React, { useEffect, useState } from "react";
 import { Member } from "../types/member";
 import { getAllMembers } from "../api/lib/member";
+import Events from "../components/Events";
+import { events } from "../data/seed";
 
 function HomePage(): JSX.Element {
   const [members, setMembers] = React.useState<Member[]>([]);


### PR DESCRIPTION
Added Events page, added link to sidebar, added main page touchups. Events page contains table that displays Event name, the Member assigned to the event, date of the event, the location, the budget for the event, and the type. The table is built using the ChakraUI table module. Added new routes from the main page to link to /events page. Additionally included a calendar icon module to add to the sidebar. 

(The VSCode "Prettier" extension may have reformatted some previous code.)